### PR TITLE
Preserve random label across video size changes

### DIFF
--- a/WebApp/client/public/multiplay/js/main.js
+++ b/WebApp/client/public/multiplay/js/main.js
@@ -108,6 +108,8 @@ function onConnect() {
   showStatsMessage();
 }
 
+let _num = 0;
+
 async function onOpenMultiplayChannel() {
   await new Promise(resolve => setTimeout(resolve, 100));
   const waitForOpen = () => new Promise(resolve => {
@@ -122,8 +124,8 @@ async function onOpenMultiplayChannel() {
   });
 
   await waitForOpen();
-  const num = Math.floor(Math.random() * 100000);
-  const json = JSON.stringify({ type: ActionType.ChangeLabel, argument: String(num) });
+  _num = Math.floor(Math.random() * 100000);
+  const json = JSON.stringify({ type: ActionType.ChangeLabel, argument: String(_num) });
   multiplayChannel.send(json);
   console.log('Message sent:', json);
 }
@@ -148,6 +150,9 @@ async function onVideoSizeChange(width, height) {
   const json = JSON.stringify({ type: ActionType.ChangeVideoSize, argument: String(width) + 'x' + String(height) });
   multiplayChannel.send(json);
   console.log('Message sent:', json);
+
+  json = JSON.stringify({ type: ActionType.ChangeLabel, argument: String(_num) });
+  multiplayChannel.send(json);
 }
 
 async function onDisconnect(connectionId) {


### PR DESCRIPTION
Introduced a module-level variable _num to store the random label number generated on channel open. Now, when the video size changes, the same label value is resent to maintain consistency.